### PR TITLE
Cannot use transformer together with some other transformers

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,7 +5,8 @@ const creator = new DtsCreator({ camelCase: true });
 
 module.exports = new Transformer({
     async transform({asset}) {
-        await (await creator.create(asset.filePath, "", true)).writeFile();
+        let code = await asset.getCode();
+        await (await creator.create(asset.filePath, code, true)).writeFile();
         return [asset];
     },
 });


### PR DESCRIPTION
For transforming LESS in my project I use `@parcel/transformer-less` (which is part of original `@parcel/config-default` configuration).

I figured out that this transformer (and many others) cannot be used together with `parcel-transformer-ts-css-modules`. Reason is that your plugin references transformed asset using file path:

```javascript
module.exports = new Transformer({
    async transform({asset}) {
        await (await creator.create(asset.filePath /* in case of LESS file this will be file.less */, '', true)).writeFile();
        return [asset];
    },
});
```

In case that CSS content is being transformed (in my case with LESS transformer) before it gets processed with `parcel-transformer-ts-css-modules` **this transformation is dropped by your plugin** because `parcel-transformer-ts-css-modules` loads asset using file path (so it loads non-transfomed file from filesystem).

This leads to various issues. In my case next *.css transformer in the pipeline fails because it receives LESS content instead of CSS content.

Solution is to transform code, not file path.

```javascript
module.exports = new Transformer({
    async transform({asset}) {
        let code = await asset.getCode();
        await (await creator.create(asset.filePath, code, true)).writeFile();
        return [asset];
    },
});
```

Issue reproduction: https://github.com/Poky85/demo-parcel-transformer-ts-css-modules